### PR TITLE
Updated the version of mdanalysis

### DIFF
--- a/Jupyter_Dock.yml
+++ b/Jupyter_Dock.yml
@@ -212,7 +212,7 @@ dependencies:
     - griddataformats==0.5.0
     - gsd==2.4.2
     - joblib==1.0.1
-    - mdanalysis==2.0.0.dev0
+    - mdanalysis==2.0.0
     - meeko==0.1.dev3
     - mmtf-python==1.1.2
     - msgpack==1.0.2


### PR DESCRIPTION
Pip subprocess error: Could not find a version that satisfies the requirement mdanalysis==2.0.0.dev0 (from versions: 0.7.6, 0.8.0rc2, 0.8.0rc4, 0.8.0, 0.8.1rc1, 0.8.1, 0.9.0.dev0, 0.9.0, 0.9.1, 0.9.2, 0.10.0, 0.11.0, 0.12.1, 0.13.0, 0.14.0, 0.15.0, 0.16.0, 0.16.1, 0.16.2, 0.17.0, 0.18.0, 0.19.0, 0.19.1, 0.19.2, 0.20.0, 0.20.1, 1.0.0, 1.0.1, 1.1.0, 1.1.1, 2.0.0b0, 2.0.0, 2.1.0)

Replaced "mdanalysis==2.0.0.dev0" with "mdanalysis==2.0.0".